### PR TITLE
Upgrade TypeScript to 6.0.2 and fix breaking changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # compiled output
 /dist
 /node_modules
+*.tsbuildinfo
 /linux
 /tmp
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
 				"ts-loader": "9.6.0",
 				"ts-node": "10.9.2",
 				"tsconfig-paths": "4.2.0",
-				"typescript": "5.9.3",
+				"typescript": "6.0.2",
 				"typescript-eslint": "8.61.0"
 			}
 		},
@@ -2855,6 +2855,20 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.1.0"
+			}
+		},
+		"node_modules/@nestjs/cli/node_modules/typescript": {
+			"version": "5.9.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=14.17"
 			}
 		},
 		"node_modules/@nestjs/common": {
@@ -11537,9 +11551,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
+			"integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
 			"devOptional": true,
 			"license": "Apache-2.0",
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
 		"ts-loader": "9.6.0",
 		"ts-node": "10.9.2",
 		"tsconfig-paths": "4.2.0",
-		"typescript": "5.9.3",
+		"typescript": "6.0.2",
 		"typescript-eslint": "8.61.0"
 	},
 	"jest": {

--- a/src/chat/chat.gateway.ts
+++ b/src/chat/chat.gateway.ts
@@ -3,7 +3,7 @@ import { JwtService } from '@nestjs/jwt';
 import { OnGatewayConnection, OnGatewayDisconnect, WebSocketGateway, WebSocketServer } from '@nestjs/websockets';
 import { Server } from 'http';
 import { Socket } from 'socket.io';
-import { DefaultEventsMap } from 'socket.io/dist/typed-events';
+import { DefaultEventsMap } from 'socket.io';
 
 @WebSocketGateway({
 	cors: {

--- a/src/post/post.mapper.ts
+++ b/src/post/post.mapper.ts
@@ -2,7 +2,7 @@ import { CommentResponseDTO, PostResponseDTO, ReplyResponseDTO } from '../dtos/p
 import { Comment, Post, Reply } from './post.entity';
 import { Converter, Mapper } from 'typevert';
 import { UserMapper } from '../users/user.mapper';
-import { User } from 'src/users/user.entity';
+import { User } from '../users/user.entity';
 
 export class LikedByMapper extends Converter<User[], boolean> {
 	convert(source?: User[]): boolean {

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -12,7 +12,6 @@ import {
 	UseInterceptors,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
-import { Multer } from 'multer';
 import { ApiBearerAuth, ApiBody, ApiConsumes, ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import * as fs from 'fs';
 import * as path from 'path';

--- a/src/users/users.controller.ts
+++ b/src/users/users.controller.ts
@@ -12,6 +12,7 @@ import {
 	UseInterceptors,
 } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
+import { Multer } from 'multer';
 import { ApiBearerAuth, ApiBody, ApiConsumes, ApiCreatedResponse, ApiOperation, ApiTags } from '@nestjs/swagger';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -101,7 +102,7 @@ export class UsersController {
 				.ensureAlpha()
 				.raw()
 				.toBuffer()
-				.then(async (buf) => {
+				.then(async (buf: Buffer) => {
 					const encoded = encode(new Uint8ClampedArray(buf), 64, 64, 4, 4);
 					await this.usersService.setAvatarHash(parseInt(userId), encoded);
 				}),

--- a/test/app.e2e-spec.ts
+++ b/test/app.e2e-spec.ts
@@ -1,4 +1,4 @@
-import * as request from 'supertest';
+import request from 'supertest';
 import { app } from './setup.e2e';
 
 describe('AppController (e2e)', () => {

--- a/test/auth.e2e-spec.ts
+++ b/test/auth.e2e-spec.ts
@@ -1,4 +1,4 @@
-import * as request from 'supertest';
+import request from 'supertest';
 import { app } from './setup.e2e';
 import { faker } from '@faker-js/faker';
 

--- a/test/utils.e2e.ts
+++ b/test/utils.e2e.ts
@@ -1,9 +1,9 @@
 import { faker } from '@faker-js/faker';
-import { ConversationResponseDTO } from 'src/dtos/chat.dto';
-import { CreateConversationRequestDTO } from 'src/dtos/conversation.dto';
-import * as request from 'supertest';
+import { ConversationResponseDTO } from '../src/dtos/chat.dto';
+import { CreateConversationRequestDTO } from '../src/dtos/conversation.dto';
+import request from 'supertest';
 import { app } from './setup.e2e';
-import { CreatePostDTO, PostResponseDTO } from 'src/dtos/post.dto';
+import { CreatePostDTO, PostResponseDTO } from '../src/dtos/post.dto';
 
 export async function createAccount(): Promise<{
 	username: string;

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,7 +1,4 @@
 {
 	"extends": "./tsconfig.json",
-	"compilerOptions": {
-		"rootDir": "./src"
-	},
 	"exclude": ["node_modules", "test", "dist", "**/*spec.ts", "eslint.config.mjs"]
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
 	"extends": "./tsconfig.json",
+	"compilerOptions": {
+		"rootDir": "./src"
+	},
 	"exclude": ["node_modules", "test", "dist", "**/*spec.ts", "eslint.config.mjs"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,12 +9,18 @@
 		"target": "es2017",
 		"sourceMap": true,
 		"outDir": "./dist",
-		"baseUrl": "./",
+
+		"paths": {
+			"src/*": ["./src/*"]
+		},
+
 		"incremental": true,
 		"skipLibCheck": true,
 		"allowJs": true,
 		"strict": true,
-		"strictPropertyInitialization": false
+		"strictPropertyInitialization": false,
+		"esModuleInterop": true,
+		"types": ["jest", "node"]
 	},
 	"exclude": ["node_modules", "test", "dist", "eslint.config.mjs"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,7 @@
 		"target": "es2017",
 		"sourceMap": true,
 		"outDir": "./dist",
+		"rootDir": "./src",
 
 		"paths": {
 			"src/*": ["./src/*"]
@@ -20,7 +21,7 @@
 		"strict": true,
 		"strictPropertyInitialization": false,
 		"esModuleInterop": true,
-		"types": ["jest", "node"]
+		"types": ["jest", "node", "multer"]
 	},
 	"exclude": ["node_modules", "test", "dist", "eslint.config.mjs"]
 }


### PR DESCRIPTION
- Bump typescript from 5.9.3 to 6.0.2
- Fix import paths: socket.io/dist/typed-events → socket.io, relative src paths in tests
- Replace namespace imports (import * as) with default imports for supertest and sharp
- Add esModuleInterop and types to tsconfig, replace baseUrl with paths
- Add rootDir to tsconfig.build.json (required by TS6 when using paths)
- Add Multer type import and explicit Buffer type annotation in users controller

https://claude.ai/code/session_01Px7PuvZNgYLDFR4ypDAjdu