### PR TITLE
perf: fix N+1 memory explosion in getUnreadMessagesCount

### DIFF
--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -203,22 +203,18 @@ export class ChatService {
 	}
 
 	async getUnreadMessagesCount(userId: number) {
-		const conversations = await this.conversationRepository
-			.createQueryBuilder('conversation')
-			.leftJoinAndSelect('conversation.participants', 'user')
-			.leftJoinAndSelect('conversation.messages', 'message')
-			.leftJoinAndSelect('message.author', 'author')
-			.leftJoinAndSelect('message.readBy', 'readBy')
-			.where('conversation.id in (SELECT "conversationId" FROM conversation_participants_user WHERE "userId" = :id)', {
-				id: userId,
-			})
-			.orderBy({ 'conversation.updatedAt': 'DESC' })
-			.getMany();
-
-		return conversations.reduce((prev, curr) => {
-			const unread = curr.messages.filter((m) => m.author.id != userId && !m.readBy.some((u) => u.id == userId));
-			return prev + unread.length;
-		}, 0);
+		return this.messageRepository
+			.createQueryBuilder('message')
+			.where(
+				'message."conversationId" IN (SELECT "conversationId" FROM conversation_participants_user WHERE "userId" = :userId)',
+				{ userId },
+			)
+			.andWhere('message."authorId" != :userId', { userId })
+			.andWhere(
+				'message.id NOT IN (SELECT "messageId" FROM message_read_by_user WHERE "userId" = :userId)',
+				{ userId },
+			)
+			.getCount();
 	}
 
 	async hasUnreadMessages(userId: number) {


### PR DESCRIPTION
## Summary

- Replaces `getUnreadMessagesCount()` implementation that loaded all conversations, all their messages, and all message relations (author, readBy) into memory just to count unread messages
- New implementation uses a single aggregated `COUNT` SQL query, filtering entirely in the database via the existing junction tables (`conversation_participants_user`, `message_read_by_user`)
- Eliminates the in-memory `reduce`/`filter`/`some` chain — the database does all the work in one round-trip

## Before vs After

**Before:** `O(messages × readBy_per_message)` objects loaded into Node.js heap per request

**After:** Single `SELECT COUNT(*)` with two subquery filters — no entity hydration at all

## Test plan

- [ ] Call the unread messages count endpoint and verify it returns the correct count
- [ ] Verify behaviour is identical when there are zero unread messages
- [ ] Verify count correctly excludes messages authored by the requesting user
- [ ] Verify count correctly excludes messages the user has already read

https://claude.ai/code/session_014W6mmhEtfHjMZMkvmJAvsT

---
_Generated by [Claude Code](https://claude.ai/code/session_014W6mmhEtfHjMZMkvmJAvsT)_