### PR TITLE
ci: fix build-image never running on tag push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -135,7 +135,6 @@ jobs:
   build-image:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-24.04
-    needs: [tsc, lint, test, test-e2e, test-container, test-container-e2e]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Problem

`build-image` has `if: startsWith(github.ref, 'refs/tags/v')` so it should fire on tag pushes. But it also had:

```yaml
needs: [tsc, lint, test, test-e2e, test-container, test-container-e2e]
```

Those jobs all have `if: !startsWith(github.event.head_commit.message, '[RELEASE]')`. On a tag push the commit the tag points to is the `[RELEASE]` commit, so every one of those jobs is **skipped**.

GitHub Actions behaviour: when all `needs` of a job are skipped, the job itself is silently skipped too — **regardless of its own `if` condition**. So `build-image` never ran.

## Fix

Remove the `needs` from `build-image`. The guarantee those jobs provided is already implicit: the tag is only ever created by `version-bump`, which itself `needs` all those jobs to pass first. The `if: startsWith(github.ref, 'refs/tags/v')` condition is sufficient to gate execution.

## Test plan

- [ ] Merge a commit to `main`, confirm `version-bump` fires and pushes a tag
- [ ] Confirm the tag push triggers `build-image` successfully

https://claude.ai/code/session_014W6mmhEtfHjMZMkvmJAvsT

---
_Generated by [Claude Code](https://claude.ai/code/session_014W6mmhEtfHjMZMkvmJAvsT)_