### PR TITLE
perf(chat): replace application-level duplicate conversation check with DB query

### DIFF
--- a/src/chat/chat.service.spec.ts
+++ b/src/chat/chat.service.spec.ts
@@ -623,6 +623,83 @@ describe('ChatService Test', () => {
 		).rejects.toThrow('Http Exception');
 	});
 
+	it('Can create a group conversation with users that already have a 1-on-1', async () => {
+		const authService = app.get(AuthService);
+		const userA = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+		const userB = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+		const userC = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+
+		const chatService = app.get(ChatService);
+
+		await chatService.createConversation(userA.id, { partnerIds: [userB.id] });
+
+		// Group chat with same two users + a third should be allowed
+		const group = await chatService.createConversation(userA.id, {
+			partnerIds: [userB.id, userC.id],
+		});
+
+		expect(group).toBeDefined();
+		expect(group.participants).toHaveLength(3);
+	});
+
+	it('Can create separate 1-on-1 conversations with different partners', async () => {
+		const authService = app.get(AuthService);
+		const userA = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+		const userB = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+		const userC = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+
+		const chatService = app.get(ChatService);
+
+		await chatService.createConversation(userA.id, { partnerIds: [userB.id] });
+		await chatService.createConversation(userA.id, { partnerIds: [userC.id] });
+
+		const conversations = await chatService.getConversationListForUser(userA.id);
+		expect(conversations).toHaveLength(2);
+	});
+
+	it('Can create multiple group conversations with the same set of users', async () => {
+		const authService = app.get(AuthService);
+		const userA = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+		const userB = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+		const userC = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+
+		const chatService = app.get(ChatService);
+
+		// Duplicate check only applies to 1-on-1 conversations
+		await chatService.createConversation(userA.id, { partnerIds: [userB.id, userC.id] });
+		await chatService.createConversation(userA.id, { partnerIds: [userB.id, userC.id] });
+
+		const conversations = await chatService.getConversationListForUser(userA.id);
+		expect(conversations).toHaveLength(2);
+	});
+
 	it('Change title in conversation', async () => {
 		const authService = app.get(AuthService);
 		const firstUser = await authService.register({

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -36,23 +36,20 @@ export class ChatService {
 			throw new HttpException({ error: 'Could not find creator by ID' }, 404);
 		}
 		if (partnerUsers.length === 1) {
-			const existingConversations = await this.conversationRepository
+			const exists = await this.conversationRepository
 				.createQueryBuilder('conversation')
-				.leftJoinAndSelect('conversation.participants', 'user')
+				.innerJoin('conversation.participants', 'p1', 'p1.id = :creatorId', { creatorId })
+				.innerJoin('conversation.participants', 'p2', 'p2.id = :partnerId', {
+					partnerId: partnerUsers[0].id,
+				})
 				.where(
-					'conversation.id in (SELECT "conversationId" FROM conversation_participants_user WHERE "userId" = :id)',
-					{ id: creatorId },
+					`(SELECT COUNT(*) FROM conversation_participants_user WHERE "conversationId" = conversation.id) = 2`,
 				)
-				.getMany();
+				.getCount();
 
-			existingConversations.forEach((value) => {
-				if (
-					value.participants.length === 2 &&
-					(value.participants[1].id === partnerUsers[0].id || value.participants[0].id === partnerUsers[0].id)
-				) {
-					throw new HttpException({ error: 'Single conversation with that user already exists' }, 400);
-				}
-			});
+			if (exists > 0) {
+				throw new HttpException({ error: 'Single conversation with that user already exists' }, 400);
+			}
 		}
 
 		const conversation = new Conversation();


### PR DESCRIPTION
## Summary

- `createConversation()` previously loaded **all conversations** a user participates in (with all their participants) into memory, then filtered duplicates in JavaScript
- Replaced with a single SQL query using two `INNER JOIN`s on the participants join table — one for the creator, one for the partner — plus a `COUNT` subquery to confirm it's a 1-on-1 conversation
- Eliminates a full table scan + application-level filtering in favour of an O(1) database lookup

## Problem (before)

```typescript
// Fetched every conversation + all participants into memory
const existingConversations = await this.conversationRepository
    .createQueryBuilder('conversation')
    .leftJoinAndSelect('conversation.participants', 'user')
    .where('conversation.id in (SELECT "conversationId" FROM conversation_participants_user WHERE "userId" = :id)', { id: creatorId })
    .getMany();

// Then filtered in JS
existingConversations.forEach((value) => {
    if (value.participants.length === 2 && ...) {
        throw new HttpException(...);
    }
});
```

## Fix (after)

```typescript
// Single DB query — no data loaded into memory
const exists = await this.conversationRepository
    .createQueryBuilder('conversation')
    .innerJoin('conversation.participants', 'p1', 'p1.id = :creatorId', { creatorId })
    .innerJoin('conversation.participants', 'p2', 'p2.id = :partnerId', { partnerId: partnerUsers[0].id })
    .where(`(SELECT COUNT(*) FROM conversation_participants_user WHERE "conversationId" = conversation.id) = 2`)
    .getCount();

if (exists > 0) {
    throw new HttpException({ error: 'Single conversation with that user already exists' }, 400);
}
```

## Test plan

- [ ] Create a new 1-on-1 conversation — succeeds
- [ ] Create a duplicate 1-on-1 conversation with the same user — returns 400 with correct error
- [ ] Create a group conversation with the same users — still succeeds (not affected by this check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8V42EPr2hMGSz9pkk6RVD

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8V42EPr2hMGSz9pkk6RVD)_