### PR TITLE
perf(chat): fix getConversationListForUser subquery and hasUnreadMessages over-fetching

### DIFF
--- a/src/chat/chat.service.spec.ts
+++ b/src/chat/chat.service.spec.ts
@@ -456,6 +456,166 @@ describe('ChatService Test', () => {
 		expect(unreadCount2).toBe(false);
 	});
 
+	it('hasUnreadMessages returns false when user has no conversations', async () => {
+		const authService = app.get(AuthService);
+		const user = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+
+		const chatService = app.get(ChatService);
+		const result = await chatService.hasUnreadMessages(user.id);
+		expect(result).toBe(false);
+	});
+
+	it('hasUnreadMessages returns false for the message author (own messages are not unread)', async () => {
+		const authService = app.get(AuthService);
+		const sender = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+		const receiver = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+
+		const chatService = app.get(ChatService);
+		const conversation = await chatService.createConversation(sender.id, {
+			partnerIds: [receiver.id],
+		});
+
+		await chatService.sendMessage(sender.id, conversation.id, faker.lorem.words(5), 'TEXT');
+
+		// The sender should never see their own message as unread
+		const senderHasUnread = await chatService.hasUnreadMessages(sender.id);
+		expect(senderHasUnread).toBe(false);
+	});
+
+	it('hasUnreadMessages returns true when any conversation has an unread message', async () => {
+		const authService = app.get(AuthService);
+		const userA = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+		const userB = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+		const userC = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+
+		const chatService = app.get(ChatService);
+		const conv1 = await chatService.createConversation(userA.id, { partnerIds: [userB.id] });
+		const conv2 = await chatService.createConversation(userA.id, { partnerIds: [userC.id] });
+
+		// Read all messages in conv1
+		await chatService.sendMessage(userB.id, conv1.id, faker.lorem.words(5), 'TEXT');
+		await chatService.markConversationAsRead(userA.id, conv1.id);
+
+		// Leave conv2 unread
+		await chatService.sendMessage(userC.id, conv2.id, faker.lorem.words(5), 'TEXT');
+
+		const result = await chatService.hasUnreadMessages(userA.id);
+		expect(result).toBe(true);
+	});
+
+	it('hasUnreadMessages returns false after markConversationAsRead on all conversations', async () => {
+		const authService = app.get(AuthService);
+		const userA = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+		const userB = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+		const userC = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+
+		const chatService = app.get(ChatService);
+		const conv1 = await chatService.createConversation(userA.id, { partnerIds: [userB.id] });
+		const conv2 = await chatService.createConversation(userA.id, { partnerIds: [userC.id] });
+
+		await chatService.sendMessage(userB.id, conv1.id, faker.lorem.words(5), 'TEXT');
+		await chatService.sendMessage(userC.id, conv2.id, faker.lorem.words(5), 'TEXT');
+
+		await chatService.markConversationAsRead(userA.id, conv1.id);
+		await chatService.markConversationAsRead(userA.id, conv2.id);
+
+		const result = await chatService.hasUnreadMessages(userA.id);
+		expect(result).toBe(false);
+	});
+
+	it('getConversationListForUser returns only conversations the user participates in', async () => {
+		const authService = app.get(AuthService);
+		const userA = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+		const userB = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+		const userC = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+
+		const chatService = app.get(ChatService);
+
+		// Create a conversation that userA is not part of
+		await chatService.createConversation(userB.id, { partnerIds: [userC.id] });
+
+		const conversations = await chatService.getConversationListForUser(userA.id);
+		expect(conversations).toHaveLength(0);
+	});
+
+	it('getConversationListForUser returns empty list for user with no conversations', async () => {
+		const authService = app.get(AuthService);
+		const user = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+
+		const chatService = app.get(ChatService);
+		const conversations = await chatService.getConversationListForUser(user.id);
+		expect(conversations).toHaveLength(0);
+	});
+
+	it('getConversationListForUser orders results by updatedAt descending', async () => {
+		const authService = app.get(AuthService);
+		const userA = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+		const userB = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+		const userC = await authService.register({
+			username: faker.internet.username(),
+			password: faker.internet.password(),
+		});
+
+		const chatService = app.get(ChatService);
+		const conv1 = await chatService.createConversation(userA.id, { partnerIds: [userB.id] });
+
+		// Small delay so updatedAt timestamps differ
+		await new Promise((resolve) => setTimeout(resolve, 50));
+		const conv2 = await chatService.createConversation(userA.id, { partnerIds: [userC.id] });
+
+		const conversations = await chatService.getConversationListForUser(userA.id);
+
+		expect(conversations).toHaveLength(2);
+		// Most recently created/updated comes first
+		expect(conversations[0].id).toBe(conv2.id);
+		expect(conversations[1].id).toBe(conv1.id);
+	});
+
 	it('Create conversation for invalid user', async () => {
 		const chatService = app.get(ChatService);
 		expect(

--- a/src/chat/chat.service.ts
+++ b/src/chat/chat.service.ts
@@ -62,13 +62,16 @@ export class ChatService {
 	async getConversationListForUser(userId: number) {
 		return await this.conversationRepository
 			.createQueryBuilder('conversation')
+			.innerJoin(
+				'conversation_participants_user',
+				'cpu',
+				'cpu."conversationId" = conversation.id AND cpu."userId" = :id',
+				{ id: userId },
+			)
 			.leftJoinAndSelect('conversation.participants', 'user')
 			.leftJoinAndSelect('conversation.lastMessage', 'message')
 			.leftJoinAndSelect('message.author', 'author')
 			.leftJoinAndSelect('message.readBy', 'readBy')
-			.where('conversation.id in (SELECT "conversationId" FROM conversation_participants_user WHERE "userId" = :id)', {
-				id: userId,
-			})
 			.orderBy({ 'conversation.updatedAt': 'DESC' })
 			.getMany();
 	}
@@ -215,13 +218,8 @@ export class ChatService {
 	}
 
 	async hasUnreadMessages(userId: number) {
-		const conversations = await this.getConversationListForUser(userId);
-		const result = conversations.some((c) => {
-			const unread = c.lastMessage?.author.id != userId && !c.lastMessage?.readBy.some((u) => u.id == userId);
-			return unread;
-		});
-
-		return result;
+		const count = await this.getUnreadMessagesCount(userId);
+		return count > 0;
 	}
 
 	async setConversationTitle(userId: number, conversationId: number, title: string) {


### PR DESCRIPTION
## Summary

Fixes two SQL performance issues identified in the performance review.

### Issue 6 — `getConversationListForUser`: `WHERE IN (subquery)` → `INNER JOIN`

The previous query filtered user conversations with a correlated subquery:
```sql
WHERE conversation.id IN (
  SELECT "conversationId" FROM conversation_participants_user WHERE "userId" = ?
)
```
The database re-evaluates this subquery for every candidate row. Replaced with an `INNER JOIN` on the join table directly, which the query planner resolves in a single pass:
```typescript
.innerJoin(
  'conversation_participants_user', 'cpu',
  'cpu."conversationId" = conversation.id AND cpu."userId" = :id',
  { id: userId },
)
```

### Issue 5 — `hasUnreadMessages`: full graph load → `COUNT` query

`hasUnreadMessages` previously called `getConversationListForUser()`, which issues four joins (participants, lastMessage, author, readBy) just to compute a boolean. Replaced with a delegation to `getUnreadMessagesCount()`, which runs a single `COUNT` query:
```typescript
// Before
const conversations = await this.getConversationListForUser(userId);
return conversations.some(c => c.lastMessage?.author.id != userId && !c.lastMessage?.readBy.some(...));

// After
const count = await this.getUnreadMessagesCount(userId);
return count > 0;
```

## Tests added (`chat.service.spec.ts`)

**`hasUnreadMessages`:**
- Returns `false` for a user with no conversations
- Returns `false` for the message author (own messages are never unread)
- Returns `true` when any one conversation has an unread message
- Returns `false` after `markConversationAsRead` on all conversations

**`getConversationListForUser`:**
- Returns only conversations the user participates in (not others')
- Returns an empty list for a user with no conversations
- Orders results by `updatedAt` descending

## Test plan
- [ ] `hasUnreadMessages` returns correct boolean before and after reading messages
- [ ] `getConversationListForUser` does not leak conversations from other users
- [ ] Ordering of conversation list is newest-first

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P8V42EPr2hMGSz9pkk6RVD

---
_Generated by [Claude Code](https://claude.ai/code/session_01P8V42EPr2hMGSz9pkk6RVD)_