### PR TITLE
Bump Node.js to 26.3.1 in Dockerfile and workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        node-version: [22, 24, 26.3.0]
+        node-version: [22, 24, 26.3.1]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        node-version: [22, 24, 26.3.0]
+        node-version: [22, 24, 26.3.1]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: 26.3.0
+          node-version: 26.3.1
           cache: 'npm'
       - run: npm ci
       - run: npm run test:cov
@@ -74,7 +74,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: 26.3.0
+          node-version: 26.3.1
           cache: 'npm'
       - run: npm ci
       - run: npm run lint
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-24.04
     strategy:
       matrix:
-        node-version: [22, 24, 26.3.0]
+        node-version: [22, 24, 26.3.1]
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
@@ -102,7 +102,7 @@ jobs:
           token: ${{secrets.PAT}}
       - uses: actions/setup-node@v6
         with:
-          node-version: 26.3.0
+          node-version: 26.3.1
           cache: 'npm'
       - run: |
           git config --global user.name 'Johannes Jahn'
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
-          node-version: 26.3.0
+          node-version: 26.3.1
           cache: 'npm'
       - run: npm ci
       - run: npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM node:26.3.0
+FROM node:26.3.1
 
 RUN apt update && apt upgrade -y
 


### PR DESCRIPTION
## Summary

Bumps Node.js from `26.3.0` to `26.3.1`.

- **Dockerfile** — `FROM node:26.3.0` → `node:26.3.1` (mirrors the `dependabot/docker/node-26.3.1` update)
- **.github/workflows/deploy.yml** — all 7 node-version references bumped to `26.3.1` (test matrices and standalone jobs)

## Note

Applied the Node bump directly on top of the current `main` rather than merging the dependabot branch, which was cut from an older `main`. Merging it would have regressed `actions/checkout@v7` → `v6`, the package version `2.1.229` → `2.1.227`, and `@faker-js/faker` `10.5.0` → `10.4.0`. This keeps those intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013qngZQNJJuENEeZMzXVMiy