### PR TITLE
Bump better-sqlite3 to 13.0.1 and resolve typeorm peer conflict

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"@nestjs/swagger": "11.4.6",
 				"@nestjs/typeorm": "11.0.3",
 				"@nestjs/websockets": "11.1.28",
-				"better-sqlite3": "^12.11.1",
+				"better-sqlite3": "^13.0.1",
 				"blurhash": "2.0.5",
 				"passport": "0.7.0",
 				"passport-jwt": "4.0.1",
@@ -1257,9 +1257,6 @@
 			"cpu": [
 				"arm"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1275,9 +1272,6 @@
 			"integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
 			"cpu": [
 				"arm64"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -1295,9 +1289,6 @@
 			"cpu": [
 				"ppc64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1313,9 +1304,6 @@
 			"integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
 			"cpu": [
 				"riscv64"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -1333,9 +1321,6 @@
 			"cpu": [
 				"s390x"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1351,9 +1336,6 @@
 			"integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
@@ -1371,9 +1353,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"musl"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1390,9 +1369,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"musl"
-			],
 			"license": "LGPL-3.0-or-later",
 			"optional": true,
 			"os": [
@@ -1408,9 +1384,6 @@
 			"integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
 			"cpu": [
 				"arm"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -1434,9 +1407,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1458,9 +1428,6 @@
 			"integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
 			"cpu": [
 				"ppc64"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -1484,9 +1451,6 @@
 			"cpu": [
 				"riscv64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1508,9 +1472,6 @@
 			"integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
 			"cpu": [
 				"s390x"
-			],
-			"libc": [
-				"glibc"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -1534,9 +1495,6 @@
 			"cpu": [
 				"x64"
 			],
-			"libc": [
-				"glibc"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1559,9 +1517,6 @@
 			"cpu": [
 				"arm64"
 			],
-			"libc": [
-				"musl"
-			],
 			"license": "Apache-2.0",
 			"optional": true,
 			"os": [
@@ -1583,9 +1538,6 @@
 			"integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
 			"cpu": [
 				"x64"
-			],
-			"libc": [
-				"musl"
 			],
 			"license": "Apache-2.0",
 			"optional": true,
@@ -4881,6 +4833,7 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -4920,23 +4873,23 @@
 			}
 		},
 		"node_modules/better-sqlite3": {
-			"version": "12.11.1",
-			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-12.11.1.tgz",
-			"integrity": "sha512-dq9AtApgg5PGFtBzPFSBl3HZQjHok5gaQCM6zh2Yk0aSmDCs1CbnVI8/HgASQkNKsWFpseIO9beg5xxpYhbIfA==",
+			"version": "13.0.1",
+			"resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.1.tgz",
+			"integrity": "sha512-LYpmOXdkpQYf4wmlxkdzW01XGlOXNIbjLg45yNkh0FQ4814VbK9PdOFmhZpYbej+EZtR/i3FDdhEG98HqZdgnA==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {
-				"bindings": "^1.5.0",
-				"prebuild-install": "^7.1.1"
+				"node-addon-api": "^8.0.0"
 			},
 			"engines": {
-				"node": "20.x || 22.x || 23.x || 24.x || 25.x || 26.x"
+				"node": ">=22"
 			}
 		},
 		"node_modules/bindings": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
 			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"file-uri-to-path": "1.0.0"
@@ -4946,6 +4899,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
 			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"buffer": "^5.5.0",
@@ -5055,6 +5009,7 @@
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
 			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -5619,6 +5574,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
 			"integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"mimic-response": "^3.1.0"
@@ -5648,6 +5604,7 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
 			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=4.0.0"
@@ -5857,6 +5814,7 @@
 			"version": "1.4.5",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
 			"integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"once": "^1.4.0"
@@ -6414,6 +6372,7 @@
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
 			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+			"dev": true,
 			"license": "(MIT OR WTFPL)",
 			"engines": {
 				"node": ">=6"
@@ -6601,6 +6560,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
 			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/finalhandler": {
@@ -6787,6 +6747,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
 			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/fs-extra": {
@@ -6937,6 +6898,7 @@
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
 			"integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/glob": {
@@ -7278,6 +7240,7 @@
 			"version": "1.3.8",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
 			"integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/ipaddr.js": {
@@ -8682,6 +8645,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
 			"integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
@@ -8707,6 +8671,7 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
 			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+			"dev": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -8738,6 +8703,7 @@
 			"version": "0.5.3",
 			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
 			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/ms": {
@@ -8822,6 +8788,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
 			"integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/napi-postinstall": {
@@ -8867,6 +8834,7 @@
 			"version": "3.87.0",
 			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.87.0.tgz",
 			"integrity": "sha512-+CGM1L1CgmtheLcBuleyYOn7NWPVu0s0EJH2C4puxgEZb9h8QpR9G2dBfZJOAUhi7VQxuBPMd0hiISWcTyiYyQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"semver": "^7.3.5"
@@ -8886,7 +8854,6 @@
 			"version": "8.8.0",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.8.0.tgz",
 			"integrity": "sha512-c5Ko1fZJIJmzhFIkhRN76WTq+fC6tWnGy9CXA0fA+XygsWZmEwG8vmbkNqxMyoaa0Tin4djul49NzdVcJJcjeA==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^18 || ^20 || >= 21"
@@ -9589,6 +9556,7 @@
 			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
 			"integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
 			"deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"detect-libc": "^2.0.0",
@@ -9707,6 +9675,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
 			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"end-of-stream": "^1.1.0",
@@ -9783,6 +9752,7 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
 			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"dev": true,
 			"license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
 			"dependencies": {
 				"deep-extend": "^0.6.0",
@@ -9798,6 +9768,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
 			"integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -10240,6 +10211,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
 			"integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -10260,6 +10232,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
 			"integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -10770,6 +10743,7 @@
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
 			"integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"chownr": "^1.1.1",
@@ -10782,12 +10756,14 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
 			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/tar-stream": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
 			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"bl": "^4.0.3",
@@ -11283,6 +11259,7 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"safe-buffer": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 		"@nestjs/swagger": "11.4.6",
 		"@nestjs/typeorm": "11.0.3",
 		"@nestjs/websockets": "11.1.28",
-		"better-sqlite3": "^12.11.1",
+		"better-sqlite3": "^13.0.1",
 		"blurhash": "2.0.5",
 		"passport": "0.7.0",
 		"passport-jwt": "4.0.1",
@@ -48,6 +48,11 @@
 		"swagger-ui-express": "5.0.1",
 		"typeorm": "1.1.0",
 		"typevert": "0.9.11"
+	},
+	"overrides": {
+		"typeorm": {
+			"better-sqlite3": "$better-sqlite3"
+		}
 	},
 	"devDependencies": {
 		"@eslint/eslintrc": "3.3.6",


### PR DESCRIPTION
Supersedes #888 (Dependabot's better-sqlite3 12.11.1 → 13.0.1), whose CI failed.

## Problem

On #888, `npm ci` aborted immediately with `ERESOLVE`:

```
peerOptional better-sqlite3@"^12.0.0" from typeorm@1.1.0
Conflicting peer dependency: better-sqlite3@12.11.1
```

`typeorm@1.1.0` (the latest release) still declares an optional peer of `better-sqlite3@^12.0.0`, so bumping the root dependency to `^13.0.1` broke npm's strict peer resolution. Because `npm ci` failed, every downstream job (`tsc`, `test`, `test-e2e`) failed or was cancelled.

## Fix

Added a targeted npm `overrides` entry so typeorm's `better-sqlite3` peer follows the root dependency instead of being pinned to `^12`:

```json
"overrides": {
  "typeorm": {
    "better-sqlite3": "$better-sqlite3"
  }
}
```

This is preferable to `--legacy-peer-deps` (which CI doesn't pass) because it's a scoped, self-documenting resolution that keeps the rest of the peer graph strict. The lockfile was regenerated accordingly.

## Verification (Node 22, locally)

- `npm ci` → exit 0, better-sqlite3 **13.0.1** installed
- `tsc` → clean
- unit tests → 96 passed
- e2e tests → 9 passed
- `lint` → 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016SYxDoeEXp54DVD7cEPG3Q

---
_Generated by [Claude Code](https://claude.ai/code/session_016SYxDoeEXp54DVD7cEPG3Q)_